### PR TITLE
Suppression d'un double espace

### DIFF
--- a/Blueflap/Strings/fr/Resources.resw
+++ b/Blueflap/Strings/fr/Resources.resw
@@ -433,7 +433,7 @@
     <value>EN TRAVAUX</value>
   </data>
   <data name="Welcome_Beta1.Text" xml:space="preserve">
-    <value>Nous  n'avons pas encore tout terminé mais nous étions impatients de vous montrer ce nouveau Blueflap.</value>
+    <value>Nous n'avons pas encore tout terminé mais nous étions impatients de vous montrer ce nouveau Blueflap.</value>
   </data>
   <data name="Welcome_Beta2.Text" xml:space="preserve">
     <value>Par conséquent, si certaines choses ne fonctionnent pas... c'est normal... ou presque...</value>


### PR DESCRIPTION
Dans le message de lancement, il y a un double espace.

Sinon, c'est une interface de lancement très propre, bravo. ;)
